### PR TITLE
use a more object-oriented approach for MatchMergeTransformer

### DIFF
--- a/Etl.spec.ts
+++ b/Etl.spec.ts
@@ -174,20 +174,24 @@ describe('Etl', () => {
 
     it('should process a match-merge transformer', done => {
         let spy = sinon.spy();
+
+        class TestMatchTransformer extends MatchMergeTransformer {
+            match(o1, o2) {
+                return o1.location === o2.location;
+            }
+
+            merge(o1, o2) {
+                return {
+                    location: o1.location,
+                    things: [...o1.things, ...o2.things]
+                };
+            }
+        }
+
         etl
             .addExtractor(matchMergeExtractor)
             .addLoader(loader)
-            .addGeneralTransformer(new MatchMergeTransformer(
-                (o1, o2) => {
-                    return o1.location === o2.location;
-                },
-                (o1, o2) => {
-                    return {
-                        location: o1.location,
-                        things: [...o1.things, ...o2.things]
-                    };
-                }
-            ))
+            .addGeneralTransformer(new TestMatchTransformer)
             .start()
             .subscribe(spy, () => {
                 done(new Error('did throw'));

--- a/transformers/MatchMergeTransformer.spec.ts
+++ b/transformers/MatchMergeTransformer.spec.ts
@@ -13,10 +13,17 @@ describe('MatchMergeTransformer', () => {
     it('should return an observable', () => {
         let spy = sinon.spy();
 
-        let t = new MatchMergeTransformer(
-            (o1, o2) => o1 === o2,
-            (o1, o2) => o1
-        );
+        class TestMatchMergeTransformer extends MatchMergeTransformer {
+            match(o1, o2) {
+                return o1 === o2;
+            }
+
+            merge(o1, o2) {
+                return o1;
+            }
+        }
+
+        let t = new TestMatchMergeTransformer();
         t.process(Observable.from([1, 2, 3, 2, 3]))
             .subscribe(spy, null, () => {
                 spy.should.be.calledThrice;

--- a/transformers/MatchMergeTransformer.ts
+++ b/transformers/MatchMergeTransformer.ts
@@ -1,14 +1,19 @@
 import { GeneralTransformer } from '../interfaces/GeneralTransformer';
 import {Observable} from 'rxjs';
 
-export class MatchMergeTransformer implements GeneralTransformer {
+export abstract class MatchMergeTransformer implements GeneralTransformer {
 
-    constructor(
-        private match: (o1: any, o2: any) => boolean,
-        private merge: (o1: any, o2: any) => any
-    ) { }
+    protected abstract match(o1: any, o2: any): boolean;
 
-    matchMerge(merged: any[], o2: any): any[] {
+    protected abstract merge(o1: any, o2: any): any;
+
+    public process(observable: Observable<any>): Observable<any> {
+        return observable.reduce(this.matchMerge.bind(this), []).flatMap((merged) => {
+            return Observable.from(merged);
+        });
+    }
+
+    private matchMerge(merged: any[], o2: any): any[] {
         for (let i = 0; i < merged.length; i++) {
             if (this.match(merged[i], o2)) {
                 const o1 = merged.splice(i, 1)[0];
@@ -20,12 +25,6 @@ export class MatchMergeTransformer implements GeneralTransformer {
         }
         merged.push(o2);
         return merged;
-    }
-
-    process(observable: Observable<any>): Observable<any> {
-        return observable.reduce(this.matchMerge.bind(this), []).flatMap((merged) => {
-            return Observable.from(merged);
-        });
     }
 
 }


### PR DESCRIPTION
Users of proc-that can now define a Transformer that implements from MatchMergeTransformer by implementing match() and merge() methods.

```
class MyMatchMergeTransformer extends MatchMergeTransformer {
	match(o1, o2) {
		return true;
	}
	merge(o1, o2) {
		return o1;
	}
}
```
this allows to add it more easily to the pipeline

```
etl.addGeneralTransformer(new MyMatchMergeTransformer())
```